### PR TITLE
Add "Check if contentblock exists" example to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note that we didn't add anything to the `scripts` block in the post. That's OK, 
 
 We might want to check if the particular contentblock exists before using it in our template:
 
-* [Capture](http://docs.shopify.com/themes/liquid-basics/logic) contents of the `sidebar` contentlock to a variable `result`
+* [Capture](http://docs.shopify.com/themes/liquid-basics/logic) contents of the `sidebar` contentblock to a variable `result`
 * If `result` is not empty, output its contents surrounded with desired markup
 
 ```liquid


### PR DESCRIPTION
It might be a good idea to include a code example from the discussion in [issue #1](https://github.com/rustygeldmacher/jekyll-contentblocks/issues/1)
