### PR TITLE
Changed contentfor to contentblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ it in our template. To do this, use the `ifhascontent` tag:
 ```liquid
 {% ifhascontent javascripts %}
   <script type="text/javascript>
-    {% contentfor javascripts %}
+    {% contentblock javascripts %}
   </script>
 {% endifhascontent %}
 ```


### PR DESCRIPTION
When I used `contentfor`, jekyll was giving me an error. It worked as expected when I changed `contentfor` to `contentblock`