### PR TITLE
Loops and frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ link: "https://www.soton.ac.uk"
     <hr/>
     <div class="qualifications">
       <div class="image_carousel">
-		{% for qualification in page.contentblocks.qualifications %}
-		  <div class="vertical_layout"> 
-		    <div>
+        {% for qualification in page.contentblocks.qualifications %}
+          <div class="vertical_layout"> 
+            <div>
               <img class="popup rounded_corners mouse_over_highlight" 
                   href={{ qualification.data.photo }} alt={{ qualification.photo_alt }}>
             </div>
@@ -217,11 +217,11 @@ link: "https://www.soton.ac.uk"
                 <img href={{ qualification.data.logo }}/>
               </a>
             <div class=content_box> 
-			  {{ qualification.content }}
-			</div>
-		  </div>
-	    {% endfor %}
-	  </div>
+              {{ qualification.content }}
+            </div>
+          </div>
+	{% endfor %}
+      </div>
     </div>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # jekyll-contentblocks
 
 Gives you a mechanism in Jekyll to pass content up from pages into their parent
-layouts. It's kind of like having Rails' content_for available for Jekyll.
+layouts, with front matter and loopability. It's kind of like having Rails' 
+content_for available for Jekyll.
 
 ## Installation
 
@@ -72,6 +73,159 @@ Here is my post content.
 
 Note that we didn't add anything to the `scripts` block in the post. That's OK,
 content blocks without any content will be ignored.
+
+We can write multiple blocks in our page with the same block name:
+
+```html
+---
+layout: default
+---
+
+Here are the various academic qualifications I have been awarded over the years:
+
+{% contentfor qualification %}
+# Undergraduate Degree
+* University of Edinburgh
+* **Computational Phyics BSc**
+* **Graduated**: 2018
+* Grade: Upper Second with Honours
+{% endcontentfor %}
+
+
+{% contentfor qualification %}
+# Masters' Degree
+* University of Copenhagen
+* **Advanced Machine Learning**
+* **Graduated**: 2019
+* Grade: First with Honours
+{% endcontentfor %}
+
+
+{% contentfor qualification %}
+# Doctorate
+* University of Southampton
+* **Large-Scale Modelling using Neural Networks**
+* **Completed**: 2022
+{% endcontentfor %}
+```
+
+Then we can iterate over them in the layout file like so:
+
+```html
+<html>
+  <head>
+    {% contentblock scripts %}
+  </head>
+  <body>
+    <div class="heading">
+      {{ content }}
+    </div>
+    <hr/>
+    <div class="qualifications">
+      {% for qualification in page.contentblocks.qualifications %}
+        {{ qualification.content }}
+      {% endfor %}
+    </div>
+  </body>
+</html>
+```
+
+For each block type, an object is available under `page.contentblocks` with the block type's name. 
+The different blocks are then in an array under this object. We can access the content using
+ the key `content`, but we can also use the key `data` to access
+any front matter from the block. This allows us quite a fine level of control in our posts, 
+and allows adding quite complex pages but sourcing the data only from some very simple markdown,
+that a client without technical knowledge, for example, would be able to edit.
+
+Using the above example, say that we want to add an image of our graduation ceremony,
+a link to the university's website, and a logo for the university. This would look
+a bit clumsy if done in plain markdown, because the text would be inline, but by using front 
+matter we can specify the images just as links, format these nicely within html, and include
+our specific content afterwards:
+
+```html
+---
+layout: default
+---
+
+Here are the various academic qualifications I have been awarded over the years:
+
+{% contentfor qualification %}
+---
+photo: /img/uoe-graduation-2018.jpg
+photo_alt: "I will never forget the day I graduated in the beautiful McEwan Hall, in front of friends and family."
+logo: "https://www.ed.ac.uk/assets/logo_big.png"
+link: "https://www.ed.ac.uk/"
+---
+# Undergraduate Degree
+* University of Edinburgh
+* **Computational Phyics BSc**
+* **Graduated**: 2018
+* Grade: Upper Second with Honours
+{% endcontentfor %}
+
+
+{% contentfor qualification %}
+---
+photo: /img/masters.jpg
+photo_alt: "Copenhagen is quite possibly the most beautiful city in Europe; studying here was a pleasure and a privilege"
+logo: "/img/ku.jpg"
+link: "https://www.ku.dk/"
+---
+# Masters' Degree
+* University of Copenhagen
+* **Advanced Machine Learning**
+* **Graduated**: 2019
+* Grade: First with Honours
+{% endcontentfor %}
+
+
+{% contentfor qualification %}
+---
+photo: /img/soton.png
+photo_alt: "So glad to have that final viva voce out of the way!"
+logo: "https://soton.ac.uk/assets/logos/soton-logo.jpg"
+link: "https://www.soton.ac.uk"
+---
+# Doctorate
+* University of Southampton
+* **Large-Scale Modelling using Neural Networks**
+* **Completed**: 2022
+{% endcontentfor %}
+```
+
+```html
+<html>
+  <head>
+    {% contentblock scripts %}
+  </head>
+  <body>
+    <div class="Heading">
+      {{ content }}
+    </div>
+    <hr/>
+    <div class="qualifications">
+      <div class="image_carousel">
+		{% for qualification in page.contentblocks.qualifications %}
+		  <div class="vertical_layout"> 
+		    <div>
+              <img class="popup rounded_corners mouse_over_highlight" 
+                  href={{ qualification.data.photo }} alt={{ qualification.photo_alt }}>
+            </div>
+            <div>
+              <a href={{ qualification.data.link }}>
+                <img href={{ qualification.data.logo }}/>
+              </a>
+            <div class=content_box> 
+			  {{ qualification.content }}
+			</div>
+		  </div>
+	    {% endfor %}
+	  </div>
+    </div>
+  </body>
+</html>
+```
 
 ### Skipping content conversion in a block
 

--- a/lib/jekyll/content_blocks/content_block_tag.rb
+++ b/lib/jekyll/content_blocks/content_block_tag.rb
@@ -30,6 +30,13 @@ module Jekyll
         environment['contentblocks'] ||= {}
         environment['contentblocks'][content_block_name] ||= []
       end
+      
+      def converted_content(block_content, context)
+        converters = context.environments.first['converters']
+        Array(converters).reduce(block_content) do |content, converter|
+          converter.convert(content)
+        end
+      end
     end
   end
 end

--- a/lib/jekyll/tags/content_for.rb
+++ b/lib/jekyll/tags/content_for.rb
@@ -5,7 +5,24 @@ module Jekyll
       alias_method :render_block, :render
 
       def render(context)
-        content_for_block(context) << render_block(context)
+      
+        rendered_block = render_block(context)
+        
+        if rendered_block =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+          rendered_block = $POSTMATCH
+          data = SafeYAML.load(Regexp.last_match(1))
+          
+        elsif rendered_block.lstrip =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+          rendered_block = $POSTMATCH
+          data = SafeYAML.load(Regexp.last_match(1))
+          
+        end
+
+        content_for_block(context) << rendered_block
+        context['page']['contentblocks'] ||= {}
+        context['page']['contentblocks'][content_block_name] ||= []
+        context['page']['contentblocks'][content_block_name] << { 'content' => converted_content(rendered_block, context), 'data' => data }
+        
         ''
       end
     end

--- a/test/_layouts/default.html
+++ b/test/_layouts/default.html
@@ -24,6 +24,23 @@
         This is the default sidebar
       </div>
     {% endifnothascontent %}
+    
+    
+    {% ifhascontent multi %}
+		Individually, there should be three sections here   	
+		
+		{% for section in page.contentblocks.multi %}
+			Section {% section.data.number %}:
+			{% section.content %}
+		{% endfor %}
+		
+		And all three should appear here:
+		
+		{% contentblock multi %}
+    	
+    	
+    {% endifhascontent %}
+    
 
     {% ifhascontent footer %}
       {% contentblock footer %}

--- a/test/page3.md
+++ b/test/page3.md
@@ -1,0 +1,30 @@
+---
+title: Page Three
+layout: default
+---
+
+# CONTENT
+
+This page has multiple content sections under the same name.
+
+{% contentfor multi %}
+---
+number: 1
+---
+  The first section
+{% endcontentfor %}
+
+{% contentfor multi %}
+---
+number: 2
+---
+  The second section
+{% endcontentfor %}
+
+{% contentfor multi %}
+---
+number: 3
+---
+  The third section
+{% endcontentfor %}
+


### PR DESCRIPTION
Awesome plugin for a start! I've just made the small change of putting each block's rendered content into a variable in liquid so that we can use the same block tag to define multiple similar items and the loop through them. The existing functionality hasn't changed, so it is possible to use the `{% contentblock hello %}` directive but also it's possible to accesss individual blocks with the same name through an array in `page.contentblocks.hello`. I've also added processing of frontmatter, which goes into data, whilst the content goes into content - I've updated the readme and the tests and this should hopefully explain better than I am now.

Cheers