### PR TITLE
Support repeated content blocks with front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,52 @@ Similarly, there's the opposite tag, `ifnothascontent`:
 {% endifnothascontent %}
 ```
 
+### Repeating a block and reading its front matter
+
+You can use the same block name more than once on a page. Each block is
+collected into an array available in the layout at `contentblocks.<name>`,
+so you can loop over the individual blocks instead of rendering them as one
+concatenated chunk.
+
+Each block may also start with its own YAML front matter. The front matter is
+parsed into a `data` hash, and the remaining Markdown becomes `content`
+(converted just like a normal block). This lets an author write a few simple
+Markdown blocks while the layout arranges them into something richer.
+
+For example, a page with a list of testimonials:
+
+```liquid
+{% contentfor testimonial %}
+---
+author: Ada Lovelace
+---
+A **delightful** plugin.
+{% endcontentfor %}
+
+{% contentfor testimonial %}
+---
+author: Alan Turing
+---
+Saved us hours of work.
+{% endcontentfor %}
+```
+
+The layout can then loop over them, reading each block's `content` and `data`:
+
+```liquid
+<ul class="testimonials">
+  {% for testimonial in contentblocks.testimonial %}
+    <li>
+      {{ testimonial.content }}
+      <cite>{{ testimonial.data.author }}</cite>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+The original `{% contentblock testimonial %}` tag still works too — it renders
+all of the blocks together.
+
 ## Contributing
 
 1. Fork it

--- a/lib/jekyll/content_blocks/content_block_tag.rb
+++ b/lib/jekyll/content_blocks/content_block_tag.rb
@@ -21,14 +21,34 @@ module Jekyll
       end
 
       def block_has_content?(context)
-        block_content = content_for_block(context).join
-        !(block_content.nil? || block_content.empty?)
+        !raw_block_content(context).empty?
       end
 
+      # Each stored block is a hash: "raw" (the block body), "content" (that body
+      # converted) and "data" (the block's own front matter). The array is exposed
+      # to layouts as contentblocks.<name> so they can be looped over.
       def content_for_block(context)
         environment = context.environments.first
         environment["contentblocks"] ||= {}
         environment["contentblocks"][content_block_name] ||= []
+      end
+
+      def raw_block_content(context)
+        content_for_block(context).map { |block| block["raw"] }.join
+      end
+
+      # Convert content with the document's converters, derived from the render
+      # context (so we don't depend on the pre-render hook stashing them).
+      def converted_content(content, context)
+        Array(converters_for(context)).reduce(content) do |result, converter|
+          converter.convert(result)
+        end
+      end
+
+      def converters_for(context)
+        site = context.registers[:site]
+        extension = File.extname(context.registers[:page]["path"].to_s)
+        site.converters.select { |converter| converter.matches(extension) }
       end
     end
   end

--- a/lib/jekyll/tags/content_block.rb
+++ b/lib/jekyll/tags/content_block.rb
@@ -4,7 +4,7 @@ module Jekyll
       include ::Jekyll::ContentBlocks::ContentBlockTag
 
       def render(context)
-        block_content = content_for_block(context).join
+        block_content = raw_block_content(context)
         if convert_content?
           converted_content(block_content, context)
         else
@@ -16,20 +16,6 @@ module Jekyll
 
       def convert_content?
         !content_block_options.include?("no-convert")
-      end
-
-      def converted_content(block_content, context)
-        Array(converters_for(context)).reduce(block_content) do |content, converter|
-          converter.convert(content)
-        end
-      end
-
-      # Derive the document's converters straight from the render context so we
-      # don't depend on the pre-render hook stashing them in the payload.
-      def converters_for(context)
-        site = context.registers[:site]
-        extension = File.extname(context.registers[:page]["path"].to_s)
-        site.converters.select { |converter| converter.matches(extension) }
       end
     end
   end

--- a/lib/jekyll/tags/content_for.rb
+++ b/lib/jekyll/tags/content_for.rb
@@ -5,8 +5,24 @@ module Jekyll
       alias_method :render_block, :render
 
       def render(context)
-        content_for_block(context) << render_block(context)
+        data, body = split_front_matter(render_block(context))
+        content_for_block(context) <<
+          {
+            "raw" => body,
+            "content" => converted_content(body, context),
+            "data" => data
+          }
         ""
+      end
+
+      private
+
+      def split_front_matter(rendered)
+        if rendered.lstrip =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+          [SafeYAML.load(Regexp.last_match(1)) || {}, $POSTMATCH]
+        else
+          [{}, rendered]
+        end
       end
     end
   end

--- a/spec/jekyll_content_blocks_spec.rb
+++ b/spec/jekyll_content_blocks_spec.rb
@@ -99,5 +99,31 @@ describe Jekyll::ContentBlocks do
         expect(item_one.css("div[class=custom-sidebar] ul li")).not_to(be_empty)
       end
     end
+
+    describe "page3.html (repeated blocks and front matter)" do
+      let(:page) { load_html("page3.html") }
+      let(:testimonials) { page.css("div.testimonials div.testimonial") }
+
+      it "collects each same-named block into contentblocks" do
+        expect(testimonials.length).to(eq(3))
+      end
+
+      it "exposes each block's front matter under data" do
+        expect(testimonials[0]["data-author"]).to(eq("Ada Lovelace"))
+        expect(testimonials[1]["data-author"]).to(eq("Alan Turing"))
+      end
+
+      it "leaves data empty for a block without front matter" do
+        expect(testimonials[2]["data-author"].to_s).to(eq(""))
+      end
+
+      it "converts each block's Markdown content" do
+        expect(testimonials[0].css("strong").text).to(eq("delightful"))
+      end
+
+      it "does not render the section on pages without those blocks" do
+        expect(index.css("div.testimonials")).to(be_empty)
+      end
+    end
   end
 end

--- a/test/_layouts/default.html
+++ b/test/_layouts/default.html
@@ -34,6 +34,16 @@
       This is the default footer.
     </div>
     {% endifnothascontent %}
+
+    {% if contentblocks.testimonial %}
+      <div class="testimonials">
+        {% for testimonial in contentblocks.testimonial %}
+          <div class="testimonial" data-author="{{ testimonial.data.author }}">
+            {{ testimonial.content }}
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
   </body>
 </html>
 

--- a/test/page3.md
+++ b/test/page3.md
@@ -1,0 +1,27 @@
+---
+title: Page Three
+layout: default
+---
+
+# CONTENT
+
+This page defines several blocks with the same name, each with its own front
+matter, and the layout loops over them.
+
+{% contentfor testimonial %}
+---
+author: Ada Lovelace
+---
+A **delightful** plugin.
+{% endcontentfor %}
+
+{% contentfor testimonial %}
+---
+author: Alan Turing
+---
+Saved us hours of work.
+{% endcontentfor %}
+
+{% contentfor testimonial %}
+Anonymous, but happy.
+{% endcontentfor %}


### PR DESCRIPTION
Adds support for **repeated content blocks, each with its own front matter** — carrying forward the idea from #24 (@stellarpower), reworked against the current codebase.

## What it does

Using the same block name more than once collects each block into an array exposed to layouts as `contentblocks.<name>`, so a layout can loop over the individual blocks instead of rendering them as one concatenated chunk. Each block may start with its own YAML front matter (parsed into `data`); the remaining Markdown becomes `content`.

```liquid
{% contentfor testimonial %}
---
author: Ada Lovelace
---
A **delightful** plugin.
{% endcontentfor %}

{% contentfor testimonial %}
---
author: Alan Turing
---
Saved us hours of work.
{% endcontentfor %}
```

```liquid
<ul class="testimonials">
  {% for testimonial in contentblocks.testimonial %}
    <li>{{ testimonial.content }} <cite>{{ testimonial.data.author }}</cite></li>
  {% endfor %}
</ul>
```

The existing `{% contentblock %}` / `{% ifhascontent %}` tags are unchanged — they still join and render all blocks of a name together (front matter is stripped, so it never leaks into that output).

## Notes / deviations from #24

- **Stored in the render environment, not on the page.** Mutating the `page` object doesn't survive the page → layout render consistently across the Jekyll versions we test (3.0–4.4) — some versions worked, others didn't, in opposite ways. The environment store is reliable everywhere.
- **API is `contentblocks.<name>`** (rather than `page.contentblocks.<name>`) as a result. Same shape otherwise: each entry has `content` (converted) and `data` (its front matter).
- Converters are derived from the render context, and front-matter parsing + specs were added.

## Testing

19/19 specs across all 16 Jekyll versions (3.0 → 4.4) and the Ruby matrix (2.7 / 3.3 / 3.4 / 4.0).

Supersedes #24; credit to @stellarpower (co-authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
