### PR TITLE
Test block content with {% if contentblocks.name %}

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,28 @@ formatting applied.
 
 ### Checking if a block has content
 
-We might want to check if the particular contentblock has content before using
-it in our template. To do this, use the `ifhascontent` tag:
+We might want to check whether a block has content before using it in our
+template. The simplest way is a plain Liquid `if` — each block name is exposed
+under `contentblocks`:
+
+```liquid
+{% if contentblocks.sidebar %}
+  {% contentblock sidebar %}
+{% else %}
+  <div>This is our default sidebar.</div>
+{% endif %}
+```
+
+`contentblocks.<name>` is truthy whenever the block was defined on the page, and
+`nil` otherwise. Unlike the tags below, it also composes with other conditions:
+
+```liquid
+{% if contentblocks.sidebar or page.force_sidebar %}
+  ...
+{% endif %}
+```
+
+The `ifhascontent` and `ifnothascontent` tags are also available:
 
 ```liquid
 {% ifhascontent javascripts %}
@@ -128,15 +148,10 @@ it in our template. To do this, use the `ifhascontent` tag:
 {% endifhascontent %}
 ```
 
-Similarly, there's the opposite tag, `ifnothascontent`:
-
-```liquid
-{% ifnothascontent sidebar %}
-  <div>
-    This is our default sidebar.
-  </div>
-{% endifnothascontent %}
-```
+The difference is subtle: these tags test for **non-empty** content, whereas
+`{% if contentblocks.name %}` tests whether the block was *defined* at all. So a
+block that a page defines but leaves empty counts as "no content" for
+`ifhascontent`, yet is still present in `contentblocks`.
 
 ### Repeating a block and reading its front matter
 

--- a/lib/jekyll/content_blocks/content_block_tag.rb
+++ b/lib/jekyll/content_blocks/content_block_tag.rb
@@ -24,17 +24,24 @@ module Jekyll
         !raw_block_content(context).empty?
       end
 
-      # Each stored block is a hash: "raw" (the block body), "content" (that body
-      # converted) and "data" (the block's own front matter). The array is exposed
-      # to layouts as contentblocks.<name> so they can be looped over.
+      # Write accessor for the contentfor tag: returns the block's array, creating
+      # it if needed. Each stored block is a hash: "raw" (the block body), "content"
+      # (that body converted) and "data" (its own front matter). The store is
+      # exposed to layouts as contentblocks.<name> so they can be looped over.
       def content_for_block(context)
-        environment = context.environments.first
-        environment["contentblocks"] ||= {}
-        environment["contentblocks"][content_block_name] ||= []
+        store = (context.environments.first["contentblocks"] ||= {})
+        store[content_block_name] ||= []
+      end
+
+      # Read-only view — does NOT create an empty entry. Reading a never-defined
+      # block therefore leaves contentblocks.<name> nil (falsy) rather than an
+      # empty array (which Liquid would treat as truthy).
+      def blocks_for(context)
+        (context.environments.first["contentblocks"] || {})[content_block_name] || []
       end
 
       def raw_block_content(context)
-        content_for_block(context).map { |block| block["raw"] }.join
+        blocks_for(context).map { |block| block["raw"] }.join
       end
 
       # Convert content with the document's converters, derived from the render

--- a/spec/jekyll_content_blocks_spec.rb
+++ b/spec/jekyll_content_blocks_spec.rb
@@ -125,5 +125,32 @@ describe Jekyll::ContentBlocks do
         expect(index.css("div.testimonials")).to(be_empty)
       end
     end
+
+    describe "contentblocks variable" do
+      it "is present for a block that has content" do
+        expect(index.css("span#cb-sidebar-present")).not_to(be_empty)
+      end
+
+      it "stays nil for a block referenced by tags but with no content" do
+        # page.html renders {% ifhascontent sidebar %} but never defines a sidebar,
+        # so contentblocks.sidebar must not have been created as an empty array.
+        expect(load_html("page.html").css("span#cb-sidebar-present")).to(be_empty)
+      end
+    end
+
+    describe "a block defined but left empty" do
+      # `{% if contentblocks.x %}` tests whether the block was defined, while
+      # `ifhascontent` tests for non-empty content — so they diverge here.
+      let(:page) { load_html("emptyblock.html") }
+
+      it "is present in contentblocks (the block was defined)" do
+        expect(page.css("span#cb-sidebar-present")).not_to(be_empty)
+      end
+
+      it "counts as no content for ifhascontent / ifnothascontent" do
+        expect(page.css("div.custom-sidebar")).to(be_empty)
+        expect(page.css("div.sidebar-default")).not_to(be_empty)
+      end
+    end
   end
 end

--- a/test/_layouts/default.html
+++ b/test/_layouts/default.html
@@ -25,6 +25,10 @@
       </div>
     {% endifnothascontent %}
 
+    {% if contentblocks.sidebar %}
+      <span id="cb-sidebar-present"></span>
+    {% endif %}
+
     {% ifhascontent footer %}
       {% contentblock footer %}
     {% endifhascontent %}

--- a/test/emptyblock.md
+++ b/test/emptyblock.md
@@ -1,0 +1,8 @@
+---
+title: Empty Block
+layout: default
+---
+
+This page defines a sidebar block but leaves it empty.
+
+{% contentfor sidebar %}{% endcontentfor %}


### PR DESCRIPTION
Makes `{% if contentblocks.name %}` a reliable way to branch on a content block — the clean, composable conditional that #21 was asking for.

## The change

Reading a block (via the `contentblock` / `ifhascontent` tags) no longer creates an empty array for its name in the store — only `contentfor`, which appends, does. So a block that's *referenced* but never given content leaves `contentblocks.<name>` `nil` (falsy) instead of an empty array (which Liquid treats as truthy). That makes the plain-`if` form dependable:

```liquid
{% if contentblocks.sidebar %}
  {% contentblock sidebar %}
{% else %}
  <div>Default sidebar</div>
{% endif %}

{% if contentblocks.sidebar or page.force_sidebar %}
  ...
{% endif %}
```

## `ifhascontent` vs `contentblocks.<name>`

They differ in one subtle way, now documented and tested:

- `{% if contentblocks.name %}` → truthy if the block was **defined** on the page (even if its content is empty).
- `ifhascontent` → truthy only if the block has **non-empty** content.

So a block a page defines but leaves empty is "present" for `contentblocks` but "no content" for `ifhascontent`. (The `ifhascontent`/`ifnothascontent` tags are unchanged and still available.)

## Notes

- A `has_content` **filter** was considered but dropped — Liquid doesn't allow filters inside `{% if %}`, so it couldn't serve the compound-condition use case; the `contentblocks` variable does that cleanly.
- README reframed to lead with `{% if contentblocks.name %}`.

## Testing

24/24 specs across all 16 Jekyll versions (3.0–4.4) and the Ruby matrix, including the defined-but-empty divergence case. rubyfmt clean.

Addresses #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
