### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-contentblocks (1.2.0)
+    jekyll-contentblocks (2.0.0)
       jekyll (>= 3.0, < 5.0)
 
 GEM

--- a/jekyll-contentblocks.gemspec
+++ b/jekyll-contentblocks.gemspec
@@ -11,12 +11,16 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Provides a mechanism for passing content up to the layout, like Rails' content_for}
   gem.summary       = %q{A Jekyll plugin kind of like Rails' content_for}
   gem.homepage      = "https://github.com/rustygeldmacher/jekyll-contentblocks"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/) - ["Gemfile.lock"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  # The 3.x series is what we test and support; widen once 4.x is verified.
+  # Jekyll 3.0–3.7 rely on APIs removed in Ruby 3, so 2.7 is the effective floor.
+  gem.required_ruby_version = ">= 2.7.0"
+
+  # Supports the Jekyll 3.x and 4.x series; excludes the announced-breaking 5.x.
   gem.add_dependency('jekyll', '>= 3.0', '< 5.0')
 end

--- a/lib/jekyll/content_blocks/version.rb
+++ b/lib/jekyll/content_blocks/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module ContentBlocks
-    VERSION = "1.2.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
Version bump and release prep for **v2.0.0**.

- `version.rb` → `2.0.0` (and `Gemfile.lock`).
- gemspec: declare `required_ruby_version >= 2.7.0` (Jekyll 3.0–3.7 rely on APIs removed in Ruby 3) and `license = "MIT"` (already in `LICENSE.txt`). `gem build` is now warning-free.

See `release-notes-v2.md` for the full v2.0.0 changelog (Jekyll 4 support, `contentblocks.<name>` repeatable blocks + conditionals, dropped Jekyll < 3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)